### PR TITLE
fix issue with Render Target View Format in GraphicPipelineStateDefin…

### DIFF
--- a/Axodox.Graphics.Shared/Graphics/D3D12/States/GraphicsPipelineStateDefinition.cpp
+++ b/Axodox.Graphics.Shared/Graphics/D3D12/States/GraphicsPipelineStateDefinition.cpp
@@ -38,7 +38,9 @@ namespace Axodox::Graphics::D3D12
     };
 
     zero_memory(result.RTVFormats);
-    memcpy(result.RTVFormats, RenderTargetFormats.begin(), min(RenderTargetFormats.size(), size(result.RTVFormats)));
+  memcpy(result.RTVFormats, RenderTargetFormats.begin(),
+         min(RenderTargetFormats.size(),
+             sizeof(DXGI_FORMAT) * size(result.RTVFormats)));
 
     return result;
   }


### PR DESCRIPTION
## Issue

The `DXGI_FORMAT` type is laid out in 4 bytes of memory, although it could be represented in just 1 byte. This memcpy call does not account for this.

## Impact

This is only a concern if multiple targets are used. If only a single target is used the program functions correctly, as the only actually important byte is copied over.